### PR TITLE
Zig application

### DIFF
--- a/.github/workflows/build-zig.yml
+++ b/.github/workflows/build-zig.yml
@@ -40,9 +40,14 @@ jobs:
       - name: ✅ Run tests
         run: |
             cd apps/otel-zig
-            zig build test
+            zig build
 
-      - name: 🔨 Build (ReleaseSafe)
+      - name: ✅ Run tests
+        run: |
+            cd apps/otel-zig
+            zig test
+
+      - name: ✅ Build (ReleaseSafe)
         run: |
             cd apps/otel-zig
             zig build -Doptimize=ReleaseSafe

--- a/.github/workflows/build-zig.yml
+++ b/.github/workflows/build-zig.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        zig-version: ['0.14.0', '0.15.0']
+        zig-version: ['0.15.2']
 
     name: Zig ${{ matrix.zig-version }}
 

--- a/.github/workflows/build-zig.yml
+++ b/.github/workflows/build-zig.yml
@@ -1,0 +1,48 @@
+---
+name: Build / Zig
+
+on:
+  pull_request:
+    paths:
+      - apps/otel-zig/*.zig
+      - apps/otel-zig/build.zig
+      - apps/otel-zig/build.zig.zon
+  workflow_dispatch:  # Allow manual triggering
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        zig-version: ['0.14.0', '0.15.0']
+
+    name: Zig ${{ matrix.zig-version }}
+
+    steps:
+      - name: 🚚 Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: 🎉 Setup Zig
+        uses: mlugg/setup-zig@a28969a1e4f8096b9f3b2bf5d5e14b3cf8f16b52 # v2.0.1
+        with:
+          version: ${{ matrix.zig-version }}
+
+      - name: 🔍 Check formatting
+        run: |
+            cd apps/otel-zig
+            zig fmt --check .
+
+      - name: ✅ Run tests
+        run: |
+            cd apps/otel-zig
+            zig build test
+
+      - name: 🔨 Build (ReleaseSafe)
+        run: |
+            cd apps/otel-zig
+            zig build -Doptimize=ReleaseSafe

--- a/.github/workflows/build-zig.yml
+++ b/.github/workflows/build-zig.yml
@@ -32,12 +32,12 @@ jobs:
         with:
           version: ${{ matrix.zig-version }}
 
-      - name: 🔍 Check formatting
+      - name: ✅ Check formatting
         run: |
             cd apps/otel-zig
             zig fmt --check .
 
-      - name: ✅ Run tests
+      - name: ✅ Build application
         run: |
             cd apps/otel-zig
             zig build
@@ -47,7 +47,7 @@ jobs:
             cd apps/otel-zig
             zig test
 
-      - name: ✅ Build (ReleaseSafe)
+      - name: ✅ Build Release
         run: |
             cd apps/otel-zig
             zig build -Doptimize=ReleaseSafe

--- a/.github/workflows/build-zig.yml
+++ b/.github/workflows/build-zig.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: 🎉 Setup Zig
-        uses: mlugg/setup-zig@a28969a1e4f8096b9f3b2bf5d5e14b3cf8f16b52 # v2.0.1
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: ${{ matrix.zig-version }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ apps/otel-react/node_modules
 .venv
 **/__pycache__/
 
+# Zig
+apps/otel-zig/.zig-cache
+apps/otel-zig/zig-out

--- a/apps/otel-zig/build.zig
+++ b/apps/otel-zig/build.zig
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Note: OpenTelemetry SDK integration is pending SDK stabilization
+    // For now, this demonstrates the application structure with placeholder telemetry
+
+    // Executable
+    const exe = b.addExecutable(.{
+        .name = "otel-zig",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    b.installArtifact(exe);
+
+    // Run command
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+
+    // Tests
+    const exe_unit_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
+
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_exe_unit_tests.step);
+}

--- a/apps/otel-zig/build.zig
+++ b/apps/otel-zig/build.zig
@@ -7,8 +7,11 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    // Note: OpenTelemetry SDK integration is pending SDK stabilization
-    // For now, this demonstrates the application structure with placeholder telemetry
+    const otel_dep = b.dependency("opentelemetry", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const otel_mod = otel_dep.module("sdk");
 
     // Executable
     const exe = b.addExecutable(.{
@@ -19,6 +22,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    exe.root_module.addImport("opentelemetry-sdk", otel_mod);
 
     b.installArtifact(exe);
 
@@ -41,6 +45,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    exe_unit_tests.root_module.addImport("opentelemetry-sdk", otel_mod);
 
     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
 

--- a/apps/otel-zig/build.zig.zon
+++ b/apps/otel-zig/build.zig.zon
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+.{
+    .name = .otel_zig,
+    .version = "1.0.0",
+    .minimum_zig_version = "0.13.0",
+    .fingerprint = 0xddd44b847b4a7b61,
+
+    .dependencies = .{
+        // OpenTelemetry SDK integration pending
+        // Will be added once the SDK is stable for Zig 0.15
+    },
+
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "README.md",
+    },
+}

--- a/apps/otel-zig/build.zig.zon
+++ b/apps/otel-zig/build.zig.zon
@@ -4,7 +4,7 @@
 .{
     .name = .otel_zig,
     .version = "1.0.0",
-    .minimum_zig_version = "0.13.0",
+    .minimum_zig_version = "0.14.0",
     .fingerprint = 0xddd44b847b4a7b61,
 
     .dependencies = .{

--- a/apps/otel-zig/build.zig.zon
+++ b/apps/otel-zig/build.zig.zon
@@ -4,12 +4,14 @@
 .{
     .name = .otel_zig,
     .version = "1.0.0",
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.2",
     .fingerprint = 0xddd44b847b4a7b61,
 
     .dependencies = .{
-        // OpenTelemetry SDK integration pending
-        // Will be added once the SDK is stable for Zig 0.15
+        .opentelemetry = .{
+            .url = "git+https://github.com/zig-o11y/opentelemetry-sdk?ref=v0.1.0#f847c4f73831b0f8aa165c20d593fcde40df3212",
+            .hash = "opentelemetry-0.0.1-U_uKJxPFCQA-85CI3OYyNwe2oy7rwfWh45_2mucVrTSS",
+        },
     },
 
     .paths = .{

--- a/apps/otel-zig/src/constants.zig
+++ b/apps/otel-zig/src/constants.zig
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-/// Application version
-pub const VERSION = "1.0.0";
+//! Application-wide constants for the otel-zig service.
 
-/// Default service name
-pub const DEFAULT_SERVICE_NAME = "otel-zig";
+/// Semantic version of this application.
+pub const version = "1.0.0";
 
-/// Default HTTP port
-pub const DEFAULT_PORT = "8888";
+/// Default OpenTelemetry service name reported in telemetry.
+pub const defaultServiceName = "otel-zig";
+
+/// Default HTTP port the server binds to when EXPOSE_PORT is unset.
+pub const defaultPort = "8888";

--- a/apps/otel-zig/src/constants.zig
+++ b/apps/otel-zig/src/constants.zig
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+/// Application version
+pub const VERSION = "1.0.0";
+
+/// Default service name
+pub const DEFAULT_SERVICE_NAME = "otel-zig";
+
+/// Default HTTP port
+pub const DEFAULT_PORT = "8888";

--- a/apps/otel-zig/src/main.zig
+++ b/apps/otel-zig/src/main.zig
@@ -94,6 +94,8 @@ pub fn main() !void {
         std.process.exit(1);
     };
 
+
+
     // -----------------------------------------------------------------------
     // Logs — LoggerProvider + BatchingLogRecordProcessor + StdoutExporter
     // -----------------------------------------------------------------------

--- a/apps/otel-zig/src/main.zig
+++ b/apps/otel-zig/src/main.zig
@@ -3,15 +3,64 @@
 
 //! Entry point for the otel-zig HTTP server.
 //! Reads configuration from environment variables, starts a TCP listener,
-//! and dispatches incoming requests to route handlers.
+//! and dispatches incoming HTTP requests to route handlers.
+//!
+//! OpenTelemetry signals:
+//!   - Logs: custom std.log bridge forwards to an OTel LoggerProvider (stdout exporter)
+//!   - Traces: each request produces a server span (stdout exporter)
+//!   - Metrics: request count and latency recorded; exported every 15 s (stdout exporter)
 
 const std = @import("std");
+const sdk = @import("opentelemetry-sdk");
 const constants = @import("constants.zig");
 
 const chain_handler = @import("routing/chain.zig");
 const health_handler = @import("routing/health.zig");
 const root_handler = @import("routing/root.zig");
 const version_handler = @import("routing/version.zig");
+
+// ---------------------------------------------------------------------------
+// std.log bridge — forwards all log calls to OTel AND mirrors to stderr.
+//
+// Because the sdk.logs.Logger type is not re-exported from the SDK module,
+// we use a minimal vtable to hold the type-erased emit function.
+// ---------------------------------------------------------------------------
+
+const LogBridge = struct {
+    emit_fn: *const fn (ctx: *anyopaque, sev: u8, sev_text: []const u8, body: []const u8) void,
+    ctx: *anyopaque,
+};
+
+/// Set once in main() before the server starts; read concurrently from logFn.
+var g_log_bridge: ?LogBridge = null;
+
+pub const std_options: std.Options = .{ .logFn = otelLogFn };
+
+fn otelLogFn(
+    comptime level: std.log.Level,
+    comptime scope: @TypeOf(.enum_literal),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    const level_txt = comptime level.asText();
+    const scope_txt = "(" ++ @tagName(scope) ++ ") ";
+
+    // Mirror to stderr so the server is observable without a running collector.
+    std.debug.print(level_txt ++ ": " ++ scope_txt ++ format ++ "\n", args);
+
+    // Forward to the OTel LoggerProvider when configured.
+    if (g_log_bridge) |bridge| {
+        var msg_buf: [4096]u8 = undefined;
+        const msg = std.fmt.bufPrint(&msg_buf, format, args) catch msg_buf[0..];
+        const sev: u8 = switch (level) {
+            .err => 17,
+            .warn => 13,
+            .info => 9,
+            .debug => 5,
+        };
+        bridge.emit_fn(bridge.ctx, sev, level_txt, msg);
+    }
+}
 
 const log = std.log.scoped(.otel_zig);
 
@@ -20,16 +69,120 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    // Get configuration from environment
     const service_name = std.posix.getenv("OTEL_SERVICE_NAME") orelse constants.defaultServiceName;
     const port_str = std.posix.getenv("EXPOSE_PORT") orelse constants.defaultPort;
     const port = try std.fmt.parseInt(u16, port_str, 10);
 
-    // Setup server
-    const address = std.net.Address.initIp4(.{ 0, 0, 0, 0 }, port);
-    var server = try address.listen(.{
-        .reuse_address = true,
+    // -----------------------------------------------------------------------
+    // Logs — LoggerProvider + BatchingLogRecordProcessor + StdoutExporter
+    // -----------------------------------------------------------------------
+    const LogWriterType = std.io.GenericWriter(std.fs.File, std.fs.File.WriteError, std.fs.File.write);
+    var log_exporter = sdk.logs.StdoutExporter.init(LogWriterType{ .context = std.fs.File.stdout() });
+    const log_record_exporter = log_exporter.asLogRecordExporter();
+
+    var batch_processor = try sdk.logs.BatchingLogRecordProcessor.init(
+        allocator,
+        log_record_exporter,
+        .{
+            .max_queue_size = 512,
+            .scheduled_delay_millis = 5_000,
+            .max_export_batch_size = 64,
+        },
+    );
+    defer {
+        const proc = batch_processor.asLogRecordProcessor();
+        proc.shutdown() catch {};
+        batch_processor.deinit();
+    }
+
+    const log_resource = try sdk.attributes.Attributes.from(allocator, .{
+        "service.name",    service_name,
+        "service.version", @as([]const u8, constants.version),
     });
+    defer if (log_resource) |r| allocator.free(r);
+
+    var log_provider = try sdk.logs.LoggerProvider.init(allocator, log_resource);
+    defer log_provider.deinit();
+    try log_provider.addLogRecordProcessor(batch_processor.asLogRecordProcessor());
+
+    // Wire std.log → LoggerProvider via the type-erased bridge.
+    const logger_scope = sdk.InstrumentationScope{ .name = service_name, .version = constants.version };
+    const otel_log = try log_provider.getLogger(logger_scope);
+    const LoggerEmitBridge = struct {
+        fn emitFn(ctx: *anyopaque, sev: u8, sev_text: []const u8, body: []const u8) void {
+            const logger = @as(@TypeOf(otel_log), @ptrCast(@alignCast(ctx)));
+            logger.emit(sev, sev_text, body, null);
+        }
+    };
+    g_log_bridge = LogBridge{
+        .emit_fn = LoggerEmitBridge.emitFn,
+        .ctx = otel_log,
+    };
+
+    // -----------------------------------------------------------------------
+    // Traces — TracerProvider + SimpleProcessor + StdOutExporter
+    // -----------------------------------------------------------------------
+    var prng = std.Random.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
+    const id_generator = sdk.trace.IDGenerator{
+        .Random = sdk.trace.RandomIDGenerator.init(prng.random()),
+    };
+
+    var tracer_provider = try sdk.trace.TracerProvider.init(allocator, id_generator);
+    defer tracer_provider.shutdown();
+
+    var trace_stdout_buffer: [4096]u8 = undefined;
+    var trace_exporter = sdk.trace.StdOutExporter.init(std.fs.File.stdout().writer(&trace_stdout_buffer));
+    var trace_processor = sdk.trace.SimpleProcessor.init(allocator, trace_exporter.asSpanExporter());
+    try tracer_provider.addSpanProcessor(trace_processor.asSpanProcessor());
+
+    const tracer = try tracer_provider.getTracer(.{
+        .name = service_name,
+        .version = constants.version,
+    });
+
+    // -----------------------------------------------------------------------
+    // Metrics — MeterProvider + MetricReader + StdoutExporter
+    // A background thread calls collect() every 15 s so output is visible.
+    // -----------------------------------------------------------------------
+    const mp = try sdk.metrics.MeterProvider.default();
+    defer mp.shutdown();
+
+    const me = try sdk.metrics.MetricExporter.Stdout(allocator, null, null);
+    defer me.stdout.deinit();
+
+    const mr = try sdk.metrics.MetricReader.init(allocator, me.exporter);
+    defer mr.shutdown();
+    try mp.addReader(mr);
+
+    const meter = try mp.getMeter(.{ .name = service_name });
+
+    const request_counter = try meter.createCounter(u64, .{
+        .name = "http.server.requests",
+        .description = "Total number of HTTP requests received",
+    });
+    const request_duration = try meter.createHistogram(f64, .{
+        .name = "http.server.request_duration_ms",
+        .description = "Duration of HTTP requests in milliseconds",
+        .unit = "ms",
+    });
+
+    // Detached daemon thread: export metrics every 15 seconds.
+    const MetricsCollector = struct {
+        fn run(reader: *sdk.metrics.MetricReader) void {
+            while (true) {
+                std.Thread.sleep(15 * std.time.ns_per_s);
+                reader.collect() catch {};
+            }
+        }
+    };
+    const metrics_thread = try std.Thread.spawn(.{}, MetricsCollector.run, .{mr});
+    metrics_thread.detach();
+
+    // -----------------------------------------------------------------------
+    // HTTP server
+    // -----------------------------------------------------------------------
+    const address = std.net.Address.initIp4(.{ 0, 0, 0, 0 }, port);
+    var server = try address.listen(.{ .reuse_address = true });
     defer server.deinit();
 
     log.info("==================================================", .{});
@@ -45,12 +198,9 @@ pub fn main() !void {
     log.info("  GET /chain   - Chain of operations", .{});
     log.info("==================================================", .{});
 
-    // Accept connections
     while (true) {
         const connection = try server.accept();
-
-        // Handle connection in a new task (simplified, not truly async)
-        handleConnection(allocator, connection) catch |err| {
+        handleConnection(allocator, connection, tracer, request_counter, request_duration) catch |err| {
             log.err("connection error: {}", .{err});
         };
     }
@@ -59,17 +209,19 @@ pub fn main() !void {
 fn handleConnection(
     allocator: std.mem.Allocator,
     connection: std.net.Server.Connection,
+    tracer: anytype,
+    request_counter: *sdk.metrics.Counter(u64),
+    request_duration: *sdk.metrics.Histogram(f64),
 ) !void {
     defer connection.stream.close();
 
+    const start = std.time.milliTimestamp();
+
     var read_buffer: [8192]u8 = undefined;
     const bytes_read = try connection.stream.read(&read_buffer);
-
     if (bytes_read == 0) return;
 
     const request_str = read_buffer[0..bytes_read];
-
-    // Parse the HTTP request line
     var lines = std.mem.splitScalar(u8, request_str, '\n');
     const request_line = lines.next() orelse return;
 
@@ -78,6 +230,19 @@ fn handleConnection(
     const path = parts.next() orelse return;
 
     log.info("-> {s} {s}", .{ method, path });
+
+    // Start a server span covering the full request lifetime.
+    const span_attrs = try sdk.Attributes.from(allocator, .{
+        "http.request.method", method,
+        "url.path",            path,
+    });
+    defer if (span_attrs) |a| allocator.free(a);
+
+    var span = try tracer.startSpan(allocator, path, .{
+        .kind = .Server,
+        .attributes = span_attrs,
+    });
+    defer span.deinit();
 
     // Route handling
     const response_body = if (std.mem.eql(u8, path, "/"))
@@ -93,21 +258,33 @@ fn handleConnection(
 
     defer allocator.free(response_body);
 
-    // Determine status and content type
-    const status = if (std.mem.eql(u8, path, "/") or
+    const is_known_route =
+        std.mem.eql(u8, path, "/") or
         std.mem.eql(u8, path, "/health") or
         std.mem.eql(u8, path, "/version") or
-        std.mem.eql(u8, path, "/chain"))
-        "200 OK"
-    else
-        "404 Not Found";
+        std.mem.eql(u8, path, "/chain");
 
-    const content_type = if (std.mem.eql(u8, path, "/"))
-        "text/plain"
-    else
-        "application/json";
+    const status_code: i64 = if (is_known_route) 200 else 404;
+    const status = if (is_known_route) "200 OK" else "404 Not Found";
+    const content_type = if (std.mem.eql(u8, path, "/")) "text/plain" else "application/json";
 
-    // Build and send HTTP response
+    // Record metrics (failures are non-fatal for the request).
+    request_counter.add(1, .{
+        "http.request.method",       method,
+        "url.path",                  path,
+        "http.response.status_code", status_code,
+    }) catch |err| log.warn("counter add failed: {}", .{err});
+
+    const elapsed: f64 = @floatFromInt(std.time.milliTimestamp() - start);
+    request_duration.record(elapsed, .{ "url.path", path }) catch |err|
+        log.warn("histogram record failed: {}", .{err});
+
+    // Annotate span with response status and close it.
+    span.setAttribute("http.response.status_code", .{ .int = status_code }) catch {};
+    span.setStatus(sdk.api.trace.Status.ok());
+    span.end(null);
+
+    // Build and send HTTP response.
     const response = try std.fmt.allocPrint(
         allocator,
         "HTTP/1.1 {s}\r\nContent-Type: {s}\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}",

--- a/apps/otel-zig/src/main.zig
+++ b/apps/otel-zig/src/main.zig
@@ -1,13 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
+//! Entry point for the otel-zig HTTP server.
+//! Reads configuration from environment variables, starts a TCP listener,
+//! and dispatches incoming requests to route handlers.
+
 const std = @import("std");
 const constants = @import("constants.zig");
 
-// Import route handlers
-const root_handler = @import("routing/root.zig");
+const chain_handler = @import("routing/chain.zig");
 const health_handler = @import("routing/health.zig");
+const root_handler = @import("routing/root.zig");
 const version_handler = @import("routing/version.zig");
+
+const log = std.log.scoped(.otel_zig);
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -15,8 +21,8 @@ pub fn main() !void {
     const allocator = gpa.allocator();
 
     // Get configuration from environment
-    const service_name = std.posix.getenv("OTEL_SERVICE_NAME") orelse constants.DEFAULT_SERVICE_NAME;
-    const port_str = std.posix.getenv("EXPOSE_PORT") orelse constants.DEFAULT_PORT;
+    const service_name = std.posix.getenv("OTEL_SERVICE_NAME") orelse constants.defaultServiceName;
+    const port_str = std.posix.getenv("EXPOSE_PORT") orelse constants.defaultPort;
     const port = try std.fmt.parseInt(u16, port_str, 10);
 
     // Setup server
@@ -26,18 +32,18 @@ pub fn main() !void {
     });
     defer server.deinit();
 
-    std.debug.print("\n", .{});
-    std.debug.print("==================================================\n", .{});
-    std.debug.print("OpenTelemetry Lab - Zig Application\n", .{});
-    std.debug.print("==================================================\n", .{});
-    std.debug.print("Server listening on: http://0.0.0.0:{d}\n", .{port});
-    std.debug.print("Service Name: {s}\n", .{service_name});
-    std.debug.print("Version: {s}\n", .{constants.VERSION});
-    std.debug.print("\nAvailable endpoints:\n", .{});
-    std.debug.print("  GET /        - Root endpoint\n", .{});
-    std.debug.print("  GET /health  - Health check\n", .{});
-    std.debug.print("  GET /version - Version information\n", .{});
-    std.debug.print("==================================================\n\n", .{});
+    log.info("==================================================", .{});
+    log.info("OpenTelemetry Lab - Zig Application", .{});
+    log.info("==================================================", .{});
+    log.info("Server listening on: http://0.0.0.0:{d}", .{port});
+    log.info("Service Name: {s}", .{service_name});
+    log.info("Version: {s}", .{constants.version});
+    log.info("Available endpoints:", .{});
+    log.info("  GET /        - Root endpoint", .{});
+    log.info("  GET /health  - Health check", .{});
+    log.info("  GET /version - Version information", .{});
+    log.info("  GET /chain   - Chain of operations", .{});
+    log.info("==================================================", .{});
 
     // Accept connections
     while (true) {
@@ -45,7 +51,7 @@ pub fn main() !void {
 
         // Handle connection in a new task (simplified, not truly async)
         handleConnection(allocator, connection) catch |err| {
-            std.debug.print("Error handling connection: {}\n", .{err});
+            log.err("connection error: {}", .{err});
         };
     }
 }
@@ -71,8 +77,7 @@ fn handleConnection(
     const method = parts.next() orelse return;
     const path = parts.next() orelse return;
 
-    // Log request
-    std.debug.print("→ {s} {s}\n", .{ method, path });
+    log.info("-> {s} {s}", .{ method, path });
 
     // Route handling
     const response_body = if (std.mem.eql(u8, path, "/"))
@@ -81,6 +86,8 @@ fn handleConnection(
         try health_handler.handler(allocator)
     else if (std.mem.eql(u8, path, "/version"))
         try version_handler.handler(allocator)
+    else if (std.mem.eql(u8, path, "/chain"))
+        try chain_handler.handler(allocator)
     else
         try std.fmt.allocPrint(allocator, "{{\"error\": \"Not Found\"}}\n", .{});
 
@@ -89,7 +96,8 @@ fn handleConnection(
     // Determine status and content type
     const status = if (std.mem.eql(u8, path, "/") or
         std.mem.eql(u8, path, "/health") or
-        std.mem.eql(u8, path, "/version"))
+        std.mem.eql(u8, path, "/version") or
+        std.mem.eql(u8, path, "/chain"))
         "200 OK"
     else
         "404 Not Found";
@@ -109,10 +117,18 @@ fn handleConnection(
 
     _ = try connection.stream.writeAll(response);
 
-    std.debug.print("← {s} {s}\n", .{ status, path });
+    log.info("<- {s} {s}", .{ status, path });
+}
+
+// Register tests from all routing modules so `zig build test` picks them up.
+test {
+    _ = @import("routing/root.zig");
+    _ = @import("routing/health.zig");
+    _ = @import("routing/version.zig");
+    _ = @import("routing/chain.zig");
 }
 
 test "constants" {
-    try std.testing.expectEqualStrings("1.0.0", constants.VERSION);
-    try std.testing.expectEqualStrings("otel-zig", constants.DEFAULT_SERVICE_NAME);
+    try std.testing.expectEqualStrings("1.0.0", constants.version);
+    try std.testing.expectEqualStrings("otel-zig", constants.defaultServiceName);
 }

--- a/apps/otel-zig/src/main.zig
+++ b/apps/otel-zig/src/main.zig
@@ -94,8 +94,6 @@ pub fn main() !void {
         std.process.exit(1);
     };
 
-
-
     // -----------------------------------------------------------------------
     // Logs — LoggerProvider + BatchingLogRecordProcessor + StdoutExporter
     // -----------------------------------------------------------------------

--- a/apps/otel-zig/src/main.zig
+++ b/apps/otel-zig/src/main.zig
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+const std = @import("std");
+const constants = @import("constants.zig");
+
+// Import route handlers
+const root_handler = @import("routing/root.zig");
+const health_handler = @import("routing/health.zig");
+const version_handler = @import("routing/version.zig");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // Get configuration from environment
+    const service_name = std.posix.getenv("OTEL_SERVICE_NAME") orelse constants.DEFAULT_SERVICE_NAME;
+    const port_str = std.posix.getenv("EXPOSE_PORT") orelse constants.DEFAULT_PORT;
+    const port = try std.fmt.parseInt(u16, port_str, 10);
+
+    // Setup server
+    const address = std.net.Address.initIp4(.{ 0, 0, 0, 0 }, port);
+    var server = try address.listen(.{
+        .reuse_address = true,
+    });
+    defer server.deinit();
+
+    std.debug.print("\n", .{});
+    std.debug.print("==================================================\n", .{});
+    std.debug.print("OpenTelemetry Lab - Zig Application\n", .{});
+    std.debug.print("==================================================\n", .{});
+    std.debug.print("Server listening on: http://0.0.0.0:{d}\n", .{port});
+    std.debug.print("Service Name: {s}\n", .{service_name});
+    std.debug.print("Version: {s}\n", .{constants.VERSION});
+    std.debug.print("\nAvailable endpoints:\n", .{});
+    std.debug.print("  GET /        - Root endpoint\n", .{});
+    std.debug.print("  GET /health  - Health check\n", .{});
+    std.debug.print("  GET /version - Version information\n", .{});
+    std.debug.print("==================================================\n\n", .{});
+
+    // Accept connections
+    while (true) {
+        const connection = try server.accept();
+
+        // Handle connection in a new task (simplified, not truly async)
+        handleConnection(allocator, connection) catch |err| {
+            std.debug.print("Error handling connection: {}\n", .{err});
+        };
+    }
+}
+
+fn handleConnection(
+    allocator: std.mem.Allocator,
+    connection: std.net.Server.Connection,
+) !void {
+    defer connection.stream.close();
+
+    var read_buffer: [8192]u8 = undefined;
+    const bytes_read = try connection.stream.read(&read_buffer);
+
+    if (bytes_read == 0) return;
+
+    const request_str = read_buffer[0..bytes_read];
+
+    // Parse the HTTP request line
+    var lines = std.mem.splitScalar(u8, request_str, '\n');
+    const request_line = lines.next() orelse return;
+
+    var parts = std.mem.splitScalar(u8, request_line, ' ');
+    const method = parts.next() orelse return;
+    const path = parts.next() orelse return;
+
+    // Log request
+    std.debug.print("→ {s} {s}\n", .{ method, path });
+
+    // Route handling
+    const response_body = if (std.mem.eql(u8, path, "/"))
+        try root_handler.handler(allocator)
+    else if (std.mem.eql(u8, path, "/health"))
+        try health_handler.handler(allocator)
+    else if (std.mem.eql(u8, path, "/version"))
+        try version_handler.handler(allocator)
+    else
+        try std.fmt.allocPrint(allocator, "{{\"error\": \"Not Found\"}}\n", .{});
+
+    defer allocator.free(response_body);
+
+    // Determine status and content type
+    const status = if (std.mem.eql(u8, path, "/") or
+        std.mem.eql(u8, path, "/health") or
+        std.mem.eql(u8, path, "/version"))
+        "200 OK"
+    else
+        "404 Not Found";
+
+    const content_type = if (std.mem.eql(u8, path, "/"))
+        "text/plain"
+    else
+        "application/json";
+
+    // Build and send HTTP response
+    const response = try std.fmt.allocPrint(
+        allocator,
+        "HTTP/1.1 {s}\r\nContent-Type: {s}\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}",
+        .{ status, content_type, response_body.len, response_body },
+    );
+    defer allocator.free(response);
+
+    _ = try connection.stream.writeAll(response);
+
+    std.debug.print("← {s} {s}\n", .{ status, path });
+}
+
+test "constants" {
+    try std.testing.expectEqualStrings("1.0.0", constants.VERSION);
+    try std.testing.expectEqualStrings("otel-zig", constants.DEFAULT_SERVICE_NAME);
+}

--- a/apps/otel-zig/src/main.zig
+++ b/apps/otel-zig/src/main.zig
@@ -20,7 +20,9 @@ const root_handler = @import("routing/root.zig");
 const version_handler = @import("routing/version.zig");
 
 // ---------------------------------------------------------------------------
-// std.log bridge — forwards all log calls to OTel AND mirrors to stderr.
+// std.log bridge — forwards all log calls to OTel AND mirrors to stderr via
+// std.debug.print (active in debug builds; may be suppressed in release builds
+// depending on the optimization level).
 //
 // Because the sdk.logs.Logger type is not re-exported from the SDK module,
 // we use a minimal vtable to hold the type-erased emit function.
@@ -31,8 +33,15 @@ const LogBridge = struct {
     ctx: *anyopaque,
 };
 
-/// Set once in main() before the server starts; read concurrently from logFn.
+/// Written exactly once in main() before server.accept() is called; subsequently
+/// read from otelLogFn on any thread. No synchronization is needed because the
+/// single write completes (and std.Thread.spawn creates a memory barrier) before
+/// any concurrent reader can observe the value. If connection handling is ever
+/// moved to worker threads, this assumption must be re-evaluated.
 var g_log_bridge: ?LogBridge = null;
+
+/// Controls the background metrics-collector thread. Set to true before joining.
+var g_metrics_stop = std.atomic.Value(bool).init(false);
 
 pub const std_options: std.Options = .{ .logFn = otelLogFn };
 
@@ -45,19 +54,25 @@ fn otelLogFn(
     const level_txt = comptime level.asText();
     const scope_txt = "(" ++ @tagName(scope) ++ ") ";
 
-    // Mirror to stderr so the server is observable without a running collector.
+    // Mirror to stderr via std.debug.print. Active in debug builds; may be
+    // suppressed in release builds depending on optimization flags.
     std.debug.print(level_txt ++ ": " ++ scope_txt ++ format ++ "\n", args);
 
     // Forward to the OTel LoggerProvider when configured.
     if (g_log_bridge) |bridge| {
         var msg_buf: [4096]u8 = undefined;
         const msg = std.fmt.bufPrint(&msg_buf, format, args) catch msg_buf[0..];
+        // OTel Log Data Model severity numbers (spec §4.1):
+        //   DEBUG=5, INFO=9, WARN=13, ERROR=17
         const sev: u8 = switch (level) {
             .err => 17,
             .warn => 13,
             .info => 9,
             .debug => 5,
         };
+        // NOTE: logger.emit returns void; errors inside the SDK emit path
+        // cannot be surfaced here. Calling log.* inside this function would
+        // cause infinite recursion.
         bridge.emit_fn(bridge.ctx, sev, level_txt, msg);
     }
 }
@@ -71,7 +86,13 @@ pub fn main() !void {
 
     const service_name = std.posix.getenv("OTEL_SERVICE_NAME") orelse constants.defaultServiceName;
     const port_str = std.posix.getenv("EXPOSE_PORT") orelse constants.defaultPort;
-    const port = try std.fmt.parseInt(u16, port_str, 10);
+    const port = std.fmt.parseInt(u16, port_str, 10) catch |err| {
+        std.debug.print(
+            "ERROR: EXPOSE_PORT='{s}' is not a valid port number (1-65535): {}\n",
+            .{ port_str, err },
+        );
+        std.process.exit(1);
+    };
 
     // -----------------------------------------------------------------------
     // Logs — LoggerProvider + BatchingLogRecordProcessor + StdoutExporter
@@ -91,7 +112,11 @@ pub fn main() !void {
     );
     defer {
         const proc = batch_processor.asLogRecordProcessor();
-        proc.shutdown() catch {};
+        // Use std.debug.print here: the log bridge may already be torn down
+        // at this point, and shutdown() flushes the final in-flight log records.
+        proc.shutdown() catch |err| {
+            std.debug.print("ERROR: log processor shutdown failed, logs may be lost: {}\n", .{err});
+        };
         batch_processor.deinit();
     }
 
@@ -122,7 +147,10 @@ pub fn main() !void {
     // -----------------------------------------------------------------------
     // Traces — TracerProvider + SimpleProcessor + StdOutExporter
     // -----------------------------------------------------------------------
-    var prng = std.Random.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
+    // Use system entropy for the PRNG seed to avoid predictable IDs.
+    var seed: u64 = undefined;
+    std.crypto.random.bytes(std.mem.asBytes(&seed));
+    var prng = std.Random.DefaultPrng.init(seed);
     const id_generator = sdk.trace.IDGenerator{
         .Random = sdk.trace.RandomIDGenerator.init(prng.random()),
     };
@@ -166,17 +194,27 @@ pub fn main() !void {
         .unit = "ms",
     });
 
-    // Detached daemon thread: export metrics every 15 seconds.
+    // Background thread: export metrics every 15 s.
+    // The defer below signals the stop flag and joins the thread before
+    // mr.shutdown() / mp.shutdown() run (defers execute in LIFO order),
+    // preventing a use-after-free on the MetricReader. Shutdown may block
+    // up to 15 s waiting for the current sleep interval to complete.
     const MetricsCollector = struct {
         fn run(reader: *sdk.metrics.MetricReader) void {
-            while (true) {
+            while (!g_metrics_stop.load(.acquire)) {
                 std.Thread.sleep(15 * std.time.ns_per_s);
-                reader.collect() catch {};
+                if (g_metrics_stop.load(.acquire)) break;
+                reader.collect() catch |err| {
+                    std.log.err("metrics collect failed: {}", .{err});
+                };
             }
         }
     };
     const metrics_thread = try std.Thread.spawn(.{}, MetricsCollector.run, .{mr});
-    metrics_thread.detach();
+    defer {
+        g_metrics_stop.store(true, .release);
+        metrics_thread.join();
+    }
 
     // -----------------------------------------------------------------------
     // HTTP server
@@ -206,6 +244,11 @@ pub fn main() !void {
     }
 }
 
+// Processes one HTTP request from `connection`.
+// NOTE: The request is read in a single call; payloads exceeding 8 192 bytes
+// will be truncated. This is intentional for this demo and not production-safe.
+// NOTE: Per OTel semantic conventions, span status reflects server-side errors
+// (5xx) only; 4xx client errors are recorded with Status.ok().
 fn handleConnection(
     allocator: std.mem.Allocator,
     connection: std.net.Server.Connection,
@@ -219,15 +262,29 @@ fn handleConnection(
 
     var read_buffer: [8192]u8 = undefined;
     const bytes_read = try connection.stream.read(&read_buffer);
-    if (bytes_read == 0) return;
+    if (bytes_read == 0) {
+        log.debug("connection closed before sending data", .{});
+        return;
+    }
 
     const request_str = read_buffer[0..bytes_read];
     var lines = std.mem.splitScalar(u8, request_str, '\n');
-    const request_line = lines.next() orelse return;
+    const raw_request_line = lines.next() orelse {
+        log.warn("malformed request: no request line", .{});
+        return;
+    };
+    // HTTP lines end with \r\n; trim the trailing \r for robust parsing.
+    const request_line = std.mem.trimRight(u8, raw_request_line, "\r");
 
     var parts = std.mem.splitScalar(u8, request_line, ' ');
-    const method = parts.next() orelse return;
-    const path = parts.next() orelse return;
+    const method = parts.next() orelse {
+        log.warn("malformed request line (no method): '{s}'", .{request_line});
+        return;
+    };
+    const path = parts.next() orelse {
+        log.warn("malformed request line (no path): '{s}'", .{request_line});
+        return;
+    };
 
     log.info("-> {s} {s}", .{ method, path });
 
@@ -244,28 +301,40 @@ fn handleConnection(
     });
     defer span.deinit();
 
-    // Route handling
-    const response_body = if (std.mem.eql(u8, path, "/"))
-        try root_handler.handler(allocator)
-    else if (std.mem.eql(u8, path, "/health"))
-        try health_handler.handler(allocator)
-    else if (std.mem.eql(u8, path, "/version"))
-        try version_handler.handler(allocator)
-    else if (std.mem.eql(u8, path, "/chain"))
-        try chain_handler.handler(allocator)
-    else
-        try std.fmt.allocPrint(allocator, "{{\"error\": \"Not Found\"}}\n", .{});
-
-    defer allocator.free(response_body);
-
     const is_known_route =
         std.mem.eql(u8, path, "/") or
         std.mem.eql(u8, path, "/health") or
         std.mem.eql(u8, path, "/version") or
         std.mem.eql(u8, path, "/chain");
 
-    const status_code: i64 = if (is_known_route) 200 else 404;
-    const status = if (is_known_route) "200 OK" else "404 Not Found";
+    // Route handling — errors are caught here so we can write an HTTP 500
+    // response rather than closing the connection silently.
+    var handler_err = false;
+    const maybe_body: anyerror![]const u8 = if (std.mem.eql(u8, path, "/"))
+        root_handler.handler(allocator)
+    else if (std.mem.eql(u8, path, "/health"))
+        health_handler.handler(allocator)
+    else if (std.mem.eql(u8, path, "/version"))
+        version_handler.handler(allocator)
+    else if (std.mem.eql(u8, path, "/chain"))
+        chain_handler.handler(allocator)
+    else
+        std.fmt.allocPrint(allocator, "{{\"error\": \"Not Found\"}}\n", .{});
+
+    const response_body = maybe_body catch |err| blk: {
+        log.err("handler error for {s}: {}", .{ path, err });
+        handler_err = true;
+        break :blk try std.fmt.allocPrint(allocator, "{{\"error\": \"Internal Server Error\"}}\n", .{});
+    };
+    defer allocator.free(response_body);
+
+    const status_code: i64 = if (handler_err) 500 else if (is_known_route) 200 else 404;
+    const status = if (handler_err)
+        "500 Internal Server Error"
+    else if (is_known_route)
+        "200 OK"
+    else
+        "404 Not Found";
     const content_type = if (std.mem.eql(u8, path, "/")) "text/plain" else "application/json";
 
     // Record metrics (failures are non-fatal for the request).
@@ -280,8 +349,13 @@ fn handleConnection(
         log.warn("histogram record failed: {}", .{err});
 
     // Annotate span with response status and close it.
-    span.setAttribute("http.response.status_code", .{ .int = status_code }) catch {};
-    span.setStatus(sdk.api.trace.Status.ok());
+    // Per OTel semantic conventions, span status is set to error only for 5xx.
+    span.setAttribute("http.response.status_code", .{ .int = status_code }) catch |err|
+        log.warn("failed to set span attribute http.response.status_code: {}", .{err});
+    span.setStatus(if (handler_err)
+        sdk.api.trace.Status.error_with_description("Internal Server Error")
+    else
+        sdk.api.trace.Status.ok());
     span.end(null);
 
     // Build and send HTTP response.
@@ -292,7 +366,7 @@ fn handleConnection(
     );
     defer allocator.free(response);
 
-    _ = try connection.stream.writeAll(response);
+    try connection.stream.writeAll(response);
 
     log.info("<- {s} {s}", .{ status, path });
 }

--- a/apps/otel-zig/src/routing/chain.zig
+++ b/apps/otel-zig/src/routing/chain.zig
@@ -2,28 +2,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Route handler for the chain endpoint (GET /chain).
-//! Simulates a multi-step CPU-bound operation to demonstrate tracing spans.
+//! Simulates a CPU-bound workload so request latency is measurable via the
+//! span and histogram recorded by the caller.
 
 const std = @import("std");
 
-/// Handles GET /chain by running a simulated workload and returning
-/// a JSON summary of the completed operations.
+/// Handles GET /chain by running a simulated workload and returning a JSON body.
+/// The `operations` field is a fixed placeholder, not a computed count.
 /// Caller owns the returned slice and must free it with `allocator`.
 pub fn handler(allocator: std.mem.Allocator) ![]const u8 {
-    // Simulate a chain of operations with some CPU work
+    // Simulate a chain of operations with some CPU work.
+    // The accumulator is used in the response body below so the loop is not
+    // eliminated as dead code in optimized builds.
     var sum: u64 = 0;
     for (0..1000000) |i| {
         sum +%= i;
     }
-    // Prevent the loop from being optimized away
-    if (sum == 0) return error.Unexpected;
 
     const response = try std.fmt.allocPrint(
         allocator,
-        \\{{"message": "Chain of operations completed", "operations": 3}}
+        \\{{"message": "Chain of operations completed", "operations": 3, "checksum": {d}}}
         \\
     ,
-        .{},
+        .{sum & 0xFF},
     );
 
     return response;

--- a/apps/otel-zig/src/routing/chain.zig
+++ b/apps/otel-zig/src/routing/chain.zig
@@ -1,24 +1,36 @@
 // SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
+//! Route handler for the chain endpoint (GET /chain).
+//! Simulates a multi-step CPU-bound operation to demonstrate tracing spans.
+
 const std = @import("std");
 
+/// Handles GET /chain by running a simulated workload and returning
+/// a JSON summary of the completed operations.
+/// Caller owns the returned slice and must free it with `allocator`.
 pub fn handler(allocator: std.mem.Allocator) ![]const u8 {
     // Simulate a chain of operations with some CPU work
     var sum: u64 = 0;
     for (0..1000000) |i| {
         sum +%= i;
     }
-    // Prevent optimization
+    // Prevent the loop from being optimized away
     if (sum == 0) return error.Unexpected;
 
     const response = try std.fmt.allocPrint(
         allocator,
         \\{{"message": "Chain of operations completed", "operations": 3}}
         \\
-        ,
+    ,
         .{},
     );
 
     return response;
+}
+
+test "chain handler returns completed message" {
+    const body = try handler(std.testing.allocator);
+    defer std.testing.allocator.free(body);
+    try std.testing.expect(std.mem.indexOf(u8, body, "Chain of operations completed") != null);
 }

--- a/apps/otel-zig/src/routing/chain.zig
+++ b/apps/otel-zig/src/routing/chain.zig
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+const std = @import("std");
+
+pub fn handler(allocator: std.mem.Allocator) ![]const u8 {
+    // Simulate a chain of operations with some CPU work
+    var sum: u64 = 0;
+    for (0..1000000) |i| {
+        sum +%= i;
+    }
+    // Prevent optimization
+    if (sum == 0) return error.Unexpected;
+
+    const response = try std.fmt.allocPrint(
+        allocator,
+        \\{{"message": "Chain of operations completed", "operations": 3}}
+        \\
+        ,
+        .{},
+    );
+
+    return response;
+}

--- a/apps/otel-zig/src/routing/health.zig
+++ b/apps/otel-zig/src/routing/health.zig
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Route handler for the health check endpoint (GET /health).
+//! Always returns ok; no dependency checks are performed.
 
 const std = @import("std");
 
-/// Handles GET /health and returns a JSON body indicating service liveness.
+/// Handles GET /health and returns a JSON liveness check body.
+/// Always returns `{"status": "ok"}`; no dependency checks are performed.
 /// Caller owns the returned slice and must free it with `allocator`.
 pub fn handler(allocator: std.mem.Allocator) ![]const u8 {
     const response = try std.fmt.allocPrint(

--- a/apps/otel-zig/src/routing/health.zig
+++ b/apps/otel-zig/src/routing/health.zig
@@ -1,16 +1,26 @@
 // SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
+//! Route handler for the health check endpoint (GET /health).
+
 const std = @import("std");
 
+/// Handles GET /health and returns a JSON body indicating service liveness.
+/// Caller owns the returned slice and must free it with `allocator`.
 pub fn handler(allocator: std.mem.Allocator) ![]const u8 {
     const response = try std.fmt.allocPrint(
         allocator,
         \\{{"status": "ok"}}
         \\
-        ,
+    ,
         .{},
     );
 
     return response;
+}
+
+test "health handler returns ok status" {
+    const body = try handler(std.testing.allocator);
+    defer std.testing.allocator.free(body);
+    try std.testing.expectEqualStrings("{\"status\": \"ok\"}\n", body);
 }

--- a/apps/otel-zig/src/routing/health.zig
+++ b/apps/otel-zig/src/routing/health.zig
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+const std = @import("std");
+
+pub fn handler(allocator: std.mem.Allocator) ![]const u8 {
+    const response = try std.fmt.allocPrint(
+        allocator,
+        \\{{"status": "ok"}}
+        \\
+        ,
+        .{},
+    );
+
+    return response;
+}

--- a/apps/otel-zig/src/routing/root.zig
+++ b/apps/otel-zig/src/routing/root.zig
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+const std = @import("std");
+
+pub fn handler(allocator: std.mem.Allocator) ![]const u8 {
+    const response = try std.fmt.allocPrint(
+        allocator,
+        "OpenTelemetry Lab / Zig\n",
+        .{},
+    );
+
+    return response;
+}

--- a/apps/otel-zig/src/routing/root.zig
+++ b/apps/otel-zig/src/routing/root.zig
@@ -1,8 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
+//! Route handler for the root endpoint (GET /).
+
 const std = @import("std");
 
+/// Handles GET / and returns a plain-text application identifier.
+/// Caller owns the returned slice and must free it with `allocator`.
 pub fn handler(allocator: std.mem.Allocator) ![]const u8 {
     const response = try std.fmt.allocPrint(
         allocator,
@@ -11,4 +15,10 @@ pub fn handler(allocator: std.mem.Allocator) ![]const u8 {
     );
 
     return response;
+}
+
+test "root handler returns application identifier" {
+    const body = try handler(std.testing.allocator);
+    defer std.testing.allocator.free(body);
+    try std.testing.expectEqualStrings("OpenTelemetry Lab / Zig\n", body);
 }

--- a/apps/otel-zig/src/routing/version.zig
+++ b/apps/otel-zig/src/routing/version.zig
@@ -1,17 +1,27 @@
 // SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
+//! Route handler for the version endpoint (GET /version).
+
 const std = @import("std");
 const constants = @import("../constants.zig");
 
+/// Handles GET /version and returns a JSON body with the application version.
+/// Caller owns the returned slice and must free it with `allocator`.
 pub fn handler(allocator: std.mem.Allocator) ![]const u8 {
     const response = try std.fmt.allocPrint(
         allocator,
         \\{{"version": "{s}"}}
         \\
-        ,
-        .{constants.VERSION},
+    ,
+        .{constants.version},
     );
 
     return response;
+}
+
+test "version handler returns semver string" {
+    const body = try handler(std.testing.allocator);
+    defer std.testing.allocator.free(body);
+    try std.testing.expectEqualStrings("{\"version\": \"1.0.0\"}\n", body);
 }

--- a/apps/otel-zig/src/routing/version.zig
+++ b/apps/otel-zig/src/routing/version.zig
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+const std = @import("std");
+const constants = @import("../constants.zig");
+
+pub fn handler(allocator: std.mem.Allocator) ![]const u8 {
+    const response = try std.fmt.allocPrint(
+        allocator,
+        \\{{"version": "{s}"}}
+        \\
+        ,
+        .{constants.VERSION},
+    );
+
+    return response;
+}

--- a/apps/otel-zig/src/routing/version.zig
+++ b/apps/otel-zig/src/routing/version.zig
@@ -20,7 +20,7 @@ pub fn handler(allocator: std.mem.Allocator) ![]const u8 {
     return response;
 }
 
-test "version handler returns semver string" {
+test "version handler returns version from constants" {
     const body = try handler(std.testing.allocator);
     defer std.testing.allocator.free(body);
     try std.testing.expectEqualStrings("{\"version\": \"1.0.0\"}\n", body);


### PR DESCRIPTION
- Bootstraps a Zig HTTP server application (otel-zig) with routing for /, /health, /version, and /chain endpoints
- Integrates the OpenTelemetry SDK logs, traces, and metrics
- Implements a std.log bridge that forwards log records to the OTel LoggerProvider and mirrors output to stderr
- Uses a graceful background metrics-collection thread with atomic stop flag and join-on-shutdown
- Follows best practices