### PR TITLE
feat(victoria): add VictoriaStack observability stack support

### DIFF
--- a/docker-compose-victoriastack.yaml
+++ b/docker-compose-victoriastack.yaml
@@ -1,0 +1,82 @@
+---
+x-common: &common
+  networks:
+  - opentelemetry-lab
+  restart: unless-stopped
+  logging:
+    options:
+      max-size: 50m
+      max-file: "3"
+
+services:
+
+  otel-collector:
+    <<: *common
+    image: otel/opentelemetry-collector-contrib:0.146.0
+    container_name: otel
+    command:
+    - "--config=/conf/config.yaml"
+    volumes:
+    - ./etc/otel/otel-collector-victoriastack.yaml:/conf/config.yaml
+    ports:
+    - "4317:4317" # OTLP gRPC receiver
+    - "4318:4318" # OTLP http receiver
+    - "8889:8889" # Prometheus metrics exporter
+    environment:
+    - OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://victorialogs:9428/insert/opentelemetry/v1/logs
+    - OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://victoriametrics:8428/opentelemetry
+    - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://victoriatraces:10428/insert/opentelemetry/v1/traces
+
+  victoriametrics:
+    <<: *common
+    image: victoriametrics/victoria-metrics:v1.128.0
+    ports:
+    - "8428:8428"
+    command:
+    - "--storageDataPath=/storage"
+    - "--opentelemetry.usePrometheusNaming=true"
+    volumes:
+    - "vmdata:/storage"
+
+  victorialogs:
+    <<: *common
+    image: victoriametrics/victoria-logs:v1.36.1
+    ports:
+    - "9428:9428"
+    command:
+    - "--storageDataPath=/vlogs"
+    volumes:
+    - "vldata:/vlogs"
+
+  victoriatraces:
+    <<: *common
+    image: victoriametrics/victoria-traces:v0.4.0
+    ports:
+    - "10428:10428"
+    command:
+    - "--storageDataPath=/vtraces"
+    - "--servicegraph.enableTask=true"
+    volumes:
+    - "vtdata:/vtraces"
+
+  grafana:
+    <<: *common
+    image: grafana/grafana:12.4.0
+    ports:
+    - "3000:3000"
+    volumes:
+    # - "grdata:/var/lib/grafana"
+    - ./etc/grafana/dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml
+    - ./etc/grafana/datasource-victoriastack.yml:/etc/grafana/provisioning/datasources/datasource.yml
+    - ./etc/grafana/dashboards:/var/lib/grafana/dashboards
+    environment:
+    - GF_AUTH_ANONYMOUS_ENABLED=true
+    - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    - GF_AUTH_DISABLE_LOGIN_FORM=true
+    - GF_INSTALL_PLUGINS=victoriametrics-metrics-datasource,victoriametrics-logs-datasource
+
+volumes:
+  vmdata: {}
+  vldata: {}
+  vtdata: {}
+  # grdata: {}

--- a/etc/grafana/datasource-victoriastack.yml
+++ b/etc/grafana/datasource-victoriastack.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# config file version
+apiVersion: 1
+
+datasources:
+- uid: victoriametrics
+  orgId: 1
+  name: VictoriaMetrics
+  type: victoriametrics-metrics-datasource
+  access: proxy
+  url: http://victoriametrics:8428
+- uid: victorialogs
+  name: VictoriaLogs
+  type: victoriametrics-logs-datasource
+  url: http://victorialogs:9428
+  access: proxy
+- uid: victoriatraces
+  name: VictoriaTraces
+  type: jaeger
+  typeName: Tempo
+  access: proxy
+  url: http://victoriatraces:10428/select/jaeger

--- a/etc/otel/otel-collector-lgtm.yaml
+++ b/etc/otel/otel-collector-lgtm.yaml
@@ -24,7 +24,8 @@ receivers:
         endpoint: 0.0.0.0:4318
         cors:
           allowed_origins:
-            - http://*
+            - "http://*"
+            - "https://*"
   prometheus/collector:
     config:
       global:

--- a/etc/otel/otel-collector-victoriastack.yaml
+++ b/etc/otel/otel-collector-victoriastack.yaml
@@ -1,0 +1,57 @@
+---
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: "0.0.0.0:4318"
+        cors:
+          allowed_origins:
+            - "http://*"
+            - "https://*"
+
+exporters:
+  otlphttp/victoriametrics:
+    endpoint: ${OTEL_EXPORTER_OTLP_METRICS_ENDPOINT}
+    tls:
+      insecure: true
+  otlphttp/victorialogs:
+    logs_endpoint: ${OTEL_EXPORTER_OTLP_LOGS_ENDPOINT}
+    tls:
+      insecure: true
+  otlphttp/victoriatraces:
+    traces_endpoint: ${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT}
+    tls:
+      insecure: true
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+    path: "/ready"
+  pprof:
+    endpoint: 0.0.0.0:1777
+
+service:
+  telemetry:
+    logs:
+      encoding: json
+    # metrics:
+    #   address: 0.0.0.0:8888
+  extensions:
+    - health_check
+    - pprof
+  pipelines:
+    traces:
+      receivers:
+      - otlp
+      exporters:
+      - otlphttp/victoriatraces
+    metrics:
+      receivers:
+      - otlp
+      exporters:
+      - otlphttp/victoriametrics
+    logs:
+      receivers:
+      - otlp
+      exporters:
+      - otlphttp/victorialogs


### PR DESCRIPTION
- Adds a complete VictoriaStack-based observability setup as an alternative to the LGTM stack.
- Includes docker-compose deployment, OTEL Collector configuration routing traces/metrics/logs to
VictoriaTraces/VictoriaMetrics/VictoriaLogs, and Grafana datasource provisioning.
- Also fixes HTTPS CORS support in the LGTM OTel Collector config.